### PR TITLE
change to follow the update on good_subrel in Kruskal-AF

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: prop type
+all: prop
 
 install: prop_install type_install
 

--- a/opam
+++ b/opam
@@ -19,16 +19,16 @@ install: [
 ]
 
 depends: [
-  "coq-kruskal-trees"
-  "coq-kruskal-finite"
-  "coq-kruskal-almostfull"
-  "coq-kruskal-fan"
+  "coq-kruskal-trees"  {>= "2.0"}
+  "coq-kruskal-finite" {>= "2.0"}
+  "coq-kruskal-almostfull" {>= "2.1"}
+  "coq-kruskal-fan"    {>= "2.0"}
   "coq-kruskal-higman" {>= "2.0"}
 ]
 
 tags: [
   "category:Computer Science/Data Types and Data Structures"
-  "date:2025-12-11"
+  "date:2026-03-06"
   "logpath:KruskalVeldmanProp"
   "logpath:KruskalVeldmanType"
 ]

--- a/theories/af/afs_quasi_morphism.v
+++ b/theories/af/afs_quasi_morphism.v
@@ -168,8 +168,7 @@ Section afs_quasi_morph.
 
     + (* there is an evaluation of which all analyses are exceptional *)
       apply in_map_iff in H1 as (y & <- & H1%(in_map π₁)).
-      apply good_sub_rel; rewrite map_app; simpl; split; eauto.
-      2: apply Forall_app; auto. (* Why does the Hint fails ? *) 
+      apply good_sub_rel; rewrite map_app; simpl. 
       apply good_snoc with (1 := H1), excep_ana.
       * apply proj2_sig.
       * apply In_ana'_π₁, H2.


### PR DESCRIPTION
The change of statement `good_sub_rel` in `Kruskal-AlmostFull` generates one less sub-goal in a proof of the file `afs_quasi_morphism` herein.